### PR TITLE
add: project Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ubuntu:18.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip python3-setuptools python3-dev git g++ build-essential cmake pkg-config wget
+
+WORKDIR /src/jupyter
+
+# Install all Python packages
+RUN pip3 install setuptools_rust Cython
+RUN pip3 install git+https://github.com/ramsrigouthamg/Questgen.ai
+RUN pip3 install git+https://github.com/boudinfl/pke.git
+RUN python3 -m nltk.downloader universal_tagset
+RUN python3 -m spacy download en
+
+# Download and unpack sense2vec model
+RUN wget https://github.com/explosion/sense2vec/releases/download/v1.0.0/s2v_reddit_2015_md.tar.gz
+RUN tar -xvf  s2v_reddit_2015_md.tar.gz
+
+# Install Jupyter notebook
+RUN pip3 install jupyter
+
+# Download and set `tini` as entrypoint (see https://github.com/krallin/tini for reasons)
+ENV TINI_VERSION v0.6.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /usr/bin/tini
+RUN chmod +x /usr/bin/tini
+ENTRYPOINT ["/usr/bin/tini", "--"]
+
+# Execute Jupyter notebook
+CMD ["jupyter", "notebook", "--port=8888", "--no-browser", "--ip=0.0.0.0", "--allow-root"]

--- a/README.md
+++ b/README.md
@@ -229,6 +229,46 @@ Yes, sachin tendulkar is a former cricketer.
 ```
 </details>
 
+## 3. Use in Docker
+
+If needed (eg. due to build/install problems on MacOS), a Docker-based version can also be built and started. 
+
+This version uses an interactive Python environment called Jupyter Notebook (https://jupyter.org/).
+
+### 3.1 Prerequisites
+
+- Install Docker (see https://docs.docker.com/get-docker/).
+- Install any web browser.
+
+### 3.2 Build and start notebook
+
+Execute the following commands:
+
+```
+docker build . --tag questgen-ai:latest
+docker run -p 8888:8888 questgen-ai:latest
+```
+
+The notebook command that is run by `docker run` in the background eventually shall print its URL to the output:
+```$ docker run -p 8888:8888 hackweek:latest
+[I 08:33:50.908 NotebookApp] Writing notebook server cookie secret to /root/.local/share/jupyter/runtime/notebook_cookie_secret
+[I 08:33:51.078 NotebookApp] Serving notebooks from local directory: /src/jupyter
+[I 08:33:51.078 NotebookApp] Jupyter Notebook 6.4.8 is running at:
+[I 08:33:51.079 NotebookApp] http://e4a08a830f4e:8888/?token=c7eec1eafcf292f1595f3786f3de5dd15080d9fd277da5b0
+[I 08:33:51.079 NotebookApp]  or http://127.0.0.1:8888/?token=c7eec1eafcf292f1595f3786f3de5dd15080d9fd277da5b0
+[I 08:33:51.079 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
+[C 08:33:51.082 NotebookApp]
+
+    To access the notebook, open this file in a browser:
+        file:///root/.local/share/jupyter/runtime/nbserver-7-open.html
+    Or copy and paste one of these URLs:
+        http://e4a08a830f4e:8888/?token=c7eec1eafcf292f1595f3786f3de5dd15080d9fd277da5b0
+     or http://127.0.0.1:8888/?token=c7eec1eafcf292f1595f3786f3de5dd15080d9fd277da5b0
+```
+
+Do not exit from this command.  Copy and paste the URL starting with `127.0.0.1` to the browser to login to Jupyter. 
+By opening a new notebook the code examples above shall work.
+
 ### NLP models used
 
 For maintaining meaningfulness in Questions, Questgen uses Three T5 models. One for Boolean Question generation, one for MCQs, FAQs, Paraphrasing and one for answer generation.


### PR DESCRIPTION
Thanks for the awesome project!

I tried to install & run on MacOS Big Sur but after installing the Rust compiler got this error (when executing `pip3 install git+https://github.com/ramsrigouthamg/Questgen.ai` and installing `tokenizers==0.8.1.rc1`):

```
error[E0658]: `if` is not allowed in a `const fn`
    --> /Users/attila.toth/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.34.0/src/app/settings.rs:7:1
     |
  7  | / bitflags! {
  8  | |     struct Flags: u64 {
  9  | |         const SC_NEGATE_REQS       = 1;
  10 | |         const SC_REQUIRED          = 1 << 1;
  ...  |
  51 | |     }
  52 | | }
     | |_^
     |
     = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
     = help: add `#![feature(const_if_match)]` to the crate attributes to enable
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

  error[E0658]: `if` is not allowed in a `const fn`
    --> /Users/attila.toth/.cargo/registry/src/github.com-1ecc6299db9ec823/clap-2.34.0/src/args/settings.rs:6:1
     |
  6  | / bitflags! {
  7  | |     struct Flags: u32 {
  8  | |         const REQUIRED         = 1;
  9  | |         const MULTIPLE         = 1 << 1;
  ...  |
  28 | |     }
  29 | | }
     | |_^
     |
     = note: see issue #49146 <https://github.com/rust-lang/rust/issues/49146> for more information
     = help: add `#![feature(const_if_match)]` to the crate attributes to enable
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

```

So in order to make this work I have created a small Dockerfile to overcome this, also slightly modified the README.md if anyone else runs into this issue as well. Please see the attached PR, let me know if you have any comments!

