### PR TITLE
The sense check may not always be needed.

### DIFF
--- a/Questgen/main.py
+++ b/Questgen/main.py
@@ -114,7 +114,7 @@ class QGen:
         modified_text = joiner.join(sentences)
 
 
-        keywords = get_keywords(self.nlp,modified_text,inp['max_questions'],self.s2v,self.fdist,self.normalized_levenshtein,len(sentences) )
+        keywords = get_keywords(self.nlp,modified_text,inp['max_questions'],None,self.fdist,self.normalized_levenshtein,len(sentences) )
 
 
         keyword_sentence_mapping = get_sentences_for_keyword(keywords, sentences)

--- a/Questgen/mcq/mcq.py
+++ b/Questgen/mcq/mcq.py
@@ -206,8 +206,12 @@ def get_keywords(nlp,text,max_keywords,s2v,fdist,normalized_levenshtein,no_of_se
 
     answers = []
     for answer in total_phrases_filtered:
-        if answer not in answers and MCQs_available(answer,s2v):
-            answers.append(answer)
+        if s2v is None:
+            if answer not in answers:
+                answers.append(answer)
+        else:
+            if answer not in answers and MCQs_available(answer, s2v):
+                answers.append(answer)
 
     answers = answers[:max_keywords]
     return answers


### PR DESCRIPTION
The sense check may not always be needed. 
If the keywords result only contains one internal proper noun, such as a abbreviation, the keyword will be deleted because of sense check.