### PR TITLE
Removed spaces from README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,9 @@ pprint (output)
 
 ### 2.2 Generate MCQ Questions
 ```
-    qg = main.QGen()
-    output = qg.predict_mcq(payload)
-    pprint (output)
-    
+qg = main.QGen()
+output = qg.predict_mcq(payload)
+pprint (output)
 ```
 
 <details>


### PR DESCRIPTION
The space is limited while copying, so that the user does not have to spend time to extract it.